### PR TITLE
Adding edge-case check

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -70,7 +70,7 @@ if [ -f "${CSHARP_INSTRUMENTED_COVERAGE_REPORT}" ]; then
     TOTAL_COVERAGE_PERCENTAGE=0
     COVERAGE_SUMMARY_FILE=${CSHARP_TEST_COVERAGE_DIR}/coverage-summary-${CHALLENGE_ID}.xml
     COVERAGE_IN_PACKAGE=$(xmllint ${CSHARP_INSTRUMENTED_COVERAGE_REPORT} \
-                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'")]/Summary' || true)
+                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary' || true)
 
    echo "<xml>${COVERAGE_IN_PACKAGE}</xml>" > ${COVERAGE_SUMMARY_FILE}
    if [[ ! -z "${COVERAGE_IN_PACKAGE}" ]]; then


### PR DESCRIPTION
Adding the . after '${CHALLENGE_ID}' to ensure edge-cases are covered when client/end-user tries to use challenge id less or greater than 3 chars in length