### PR TITLE
Allow build failure propogation

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -32,6 +32,12 @@ mkdir -p ${CSHARP_TEST_COVERAGE_DIR}
 [ -e ${SCRIPT_CURRENT_DIR}/__Instrumented ] && rm -fr ${SCRIPT_CURRENT_DIR}/__Instrumented
 [ -e ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover ] && rm -fr ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover
 
+if [[ ! -e "${SCRIPT_CURRENT_DIR}/src/BeFaster.App/Solutions/${CHALLENGE_ID}" ]]; then
+   echo "" > ${CSHARP_CODE_COVERAGE_INFO}
+   echo "The provided CHALLENGE_ID: '${CHALLENGE_ID}' isn't valid, aborting process..."
+   exit 1
+fi
+
 FULL_PATH_TO_ALTCOVER="$(cd ${SCRIPT_CURRENT_DIR} && find . -path *altcover* | head -n 1 || true)"/tools/net45/AltCover.exe
 
 # Instrument the binaries so that coverage can be collected

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -76,7 +76,7 @@ if [ -f "${CSHARP_INSTRUMENTED_COVERAGE_REPORT}" ]; then
     echo ${TOTAL_COVERAGE_PERCENTAGE} > ${CSHARP_CODE_COVERAGE_INFO}
     COVERAGE_SUMMARY_FILE=${CSHARP_TEST_COVERAGE_DIR}/coverage-summary-${CHALLENGE_ID}.xml
     COVERAGE_IN_PACKAGE=$(xmllint ${CSHARP_INSTRUMENTED_COVERAGE_REPORT} \
-                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary')
+                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary' || true)
 
    echo "<xml>${COVERAGE_IN_PACKAGE}</xml>" > ${COVERAGE_SUMMARY_FILE}
    if [[ ! -z "${COVERAGE_IN_PACKAGE}" ]]; then

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -82,7 +82,7 @@ if [ -f "${CSHARP_INSTRUMENTED_COVERAGE_REPORT}" ]; then
     echo ${TOTAL_COVERAGE_PERCENTAGE} > ${CSHARP_CODE_COVERAGE_INFO}
     COVERAGE_SUMMARY_FILE=${CSHARP_TEST_COVERAGE_DIR}/coverage-summary-${CHALLENGE_ID}.xml
     COVERAGE_IN_PACKAGE=$(xmllint ${CSHARP_INSTRUMENTED_COVERAGE_REPORT} \
-                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary' || true)
+                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary')
 
    echo "<xml>${COVERAGE_IN_PACKAGE}</xml>" > ${COVERAGE_SUMMARY_FILE}
    if [[ ! -z "${COVERAGE_IN_PACKAGE}" ]]; then

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -65,7 +65,7 @@ FULL_PATH_TO_NUNIT_CONSOLE="$(cd ${SCRIPT_CURRENT_DIR} && find . -path *nunit*co
         -w ${SCRIPT_CURRENT_DIR}                                                                        \
         -- --noheader --labels=All  --work=${SCRIPT_CURRENT_DIR}                                        \
         --result=${CSHARP_TEST_RUN_REPORT}                                                              \
-        ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/BeFaster.App.Tests.dll
+        ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/BeFaster.App.Tests.dll || true
 )
 
 

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -65,7 +65,7 @@ FULL_PATH_TO_NUNIT_CONSOLE="$(cd ${SCRIPT_CURRENT_DIR} && find . -path *nunit*co
         -w ${SCRIPT_CURRENT_DIR}                                                                        \
         -- --noheader --labels=All  --work=${SCRIPT_CURRENT_DIR}                                        \
         --result=${CSHARP_TEST_RUN_REPORT}                                                              \
-        ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/BeFaster.App.Tests.dll || true
+        ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/BeFaster.App.Tests.dll
 )
 
 
@@ -73,9 +73,10 @@ FULL_PATH_TO_NUNIT_CONSOLE="$(cd ${SCRIPT_CURRENT_DIR} && find . -path *nunit*co
 
 if [ -f "${CSHARP_INSTRUMENTED_COVERAGE_REPORT}" ]; then
     TOTAL_COVERAGE_PERCENTAGE=0
+    echo ${TOTAL_COVERAGE_PERCENTAGE} > ${CSHARP_CODE_COVERAGE_INFO}
     COVERAGE_SUMMARY_FILE=${CSHARP_TEST_COVERAGE_DIR}/coverage-summary-${CHALLENGE_ID}.xml
     COVERAGE_IN_PACKAGE=$(xmllint ${CSHARP_INSTRUMENTED_COVERAGE_REPORT} \
-                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary' || true)
+                                  --xpath '//Class[starts-with(./FullName,"BeFaster.App.Solutions.'${CHALLENGE_ID}'.")]/Summary')
 
    echo "<xml>${COVERAGE_IN_PACKAGE}</xml>" > ${COVERAGE_SUMMARY_FILE}
    if [[ ! -z "${COVERAGE_IN_PACKAGE}" ]]; then


### PR DESCRIPTION
Guard clause added to coverage script to prevent detect invalid CHALLENGE_ID and abort process with exit code 1

Linked to https://github.com/julianghionoiu/dpnt-coverage/pull/34 and https://github.com/julianghionoiu/dpnt-coverage/issues/35